### PR TITLE
finite dimensional Galois cohomology?

### DIFF
--- a/BrauerGroup/RelativeBrauer.lean
+++ b/BrauerGroup/RelativeBrauer.lean
@@ -123,3 +123,105 @@ lemma split_sound' (A B : CSA F) (h0 : BrauerEquivalence A B) :
     ⟨h0.m, h0.n, h0.hm, h0.hn, h0.iso.symm⟩⟩
 
 end Defs
+
+namespace IsBrauerEquivalent
+
+open BrauerGroup
+
+variable (K : Type u) [Field K]
+
+lemma exists_common_division_algebra (A B : CSA.{u, u} K) (h : IsBrauerEquivalent A B) :
+    ∃ (D : Type u) (_ : DivisionRing D) (_ : Algebra K D)
+      (m n : ℕ) (_ : NeZero m) (_ : NeZero n),
+      Nonempty (A ≃ₐ[K] Matrix (Fin m) (Fin m) D) ∧
+      Nonempty (B ≃ₐ[K] Matrix (Fin n) (Fin n) D) := by
+  obtain ⟨n, hn, SA, _, _, ⟨isoA⟩⟩ := Wedderburn_Artin_algebra_version K A
+  -- haveI : IsCentra
+  have : NeZero n := ⟨hn⟩
+  haveI : IsCentralSimple K (Matrix (Fin n) (Fin n) SA) := AlgEquiv.isCentralSimple isoA
+  haveI : IsCentralSimple K SA := by
+    constructor
+    intro x hx
+    have mem : Matrix.diagonal (fun _ => x) ∈ Subalgebra.center K (Matrix (Fin n) (Fin n) SA) := by
+      rw [Subalgebra.mem_center_iff] at hx ⊢
+      intro m
+      ext i j
+      simp
+      apply hx
+    rw [IsCentralSimple.center_eq, Algebra.mem_bot] at mem
+    obtain ⟨c, hc⟩ := mem
+    have := Matrix.ext_iff.2 hc 0 0
+    simp only [Matrix.diagonal_apply_eq] at this
+    change algebraMap K SA c = x at this
+    subst this
+    simp only [Algebra.mem_bot, Set.mem_range, exists_apply_eq_apply]
+  have : FiniteDimensional K (Matrix (Fin n) (Fin n) SA) :=
+    Module.Finite.of_injective isoA.symm.toLinearMap isoA.symm.injective
+  have : FiniteDimensional K SA :=
+    Module.Finite.of_injective
+      ({
+        toFun := fun s => Matrix.diagonal (fun _ => s)
+        map_add' := by
+          intros
+          ext i j
+          by_cases i = j  <;> aesop
+        map_smul' := by
+          intros
+          ext i j
+          by_cases i = j  <;> aesop
+      } : SA →ₗ[K] Matrix (Fin n) (Fin n) SA) fun x y h => Matrix.ext_iff.2 h 0 0
+  have eq1 : IsBrauerEquivalent ⟨SA⟩ A := by
+    use n, 1, hn, (by linarith)
+    refine AlgEquiv.symm <| AlgEquiv.trans (dim_one_iso A) isoA
+  obtain ⟨m, hm, SB, _, _, ⟨isoB⟩⟩ := Wedderburn_Artin_algebra_version K B
+  have : NeZero m := ⟨hm⟩
+  haveI : IsCentralSimple K (Matrix (Fin m) (Fin m) SB) := AlgEquiv.isCentralSimple isoB
+  haveI : IsCentralSimple K SB := by
+    constructor
+    intro x hx
+    have mem : Matrix.diagonal (fun _ => x) ∈ Subalgebra.center K (Matrix (Fin m) (Fin m) SB) := by
+      rw [Subalgebra.mem_center_iff] at hx ⊢
+      intro m
+      ext i j
+      simp
+      apply hx
+    rw [IsCentralSimple.center_eq, Algebra.mem_bot] at mem
+    obtain ⟨c, hc⟩ := mem
+    have := Matrix.ext_iff.2 hc 0 0
+    simp only [Matrix.diagonal_apply_eq] at this
+    change algebraMap K SB c = x at this
+    subst this
+    simp only [Algebra.mem_bot, Set.mem_range, exists_apply_eq_apply]
+  have : FiniteDimensional K (Matrix (Fin m) (Fin m) SB) :=
+    Module.Finite.of_injective isoB.symm.toLinearMap isoB.symm.injective
+  have : FiniteDimensional K SB := by
+    refine FiniteDimensional.of_injective
+      (show SB →ₗ[K] Matrix (Fin m) (Fin m) SB from {
+        toFun := fun s => Matrix.diagonal fun _ => s
+        map_add' := by intros; ext i j; by_cases i = j <;> aesop
+        map_smul' := by intros; ext i j; by_cases i = j <;> aesop
+      }) ?_
+    intro _ _ H
+    exact Matrix.ext_iff.2 H 0 0
+
+  have eq2 : IsBrauerEquivalent ⟨SA⟩ B :=
+    .trans eq1 h
+
+  obtain ⟨a, a', ha, ha', e⟩ := eq2
+  haveI : NeZero m := ⟨hm⟩
+  haveI : NeZero a := ⟨ha⟩
+  haveI : NeZero a' := ⟨ha'⟩
+  haveI : NeZero (m * a) := ⟨by
+    simp only [ne_eq, mul_eq_zero, not_or]; tauto⟩
+  haveI : FiniteDimensional K (Matrix (Fin a') (Fin a') B) := by
+    apply LinearEquiv.finiteDimensional (matrixEquivTensor K B (Fin a')).toLinearEquiv.symm
+  obtain ⟨isoAB⟩ := Wedderburn_Artin_uniqueness₀ K (Matrix (Fin a') (Fin a') B) a (a' * m)
+    SA e.symm SB (by
+    refine AlgEquiv.trans (AlgEquiv.trans ?_ (Matrix.compAlgEquiv _ _ _ _)) <|
+      IsBrauerEquivalent.matrix_eqv' _ _ _
+    refine AlgEquiv.mapMatrix ?_
+    assumption)
+  refine ⟨SA, inferInstance, inferInstance, n, m, inferInstance, inferInstance,
+    ⟨⟨isoA⟩, ⟨isoB.trans <| AlgEquiv.mapMatrix isoAB.symm⟩⟩⟩
+
+end IsBrauerEquivalent

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -1039,6 +1039,44 @@ instance : Algebra F (CrossProduct ha) where
       simp only [hx, hx']
     | zero => simp
 
+@[simp]
+lemma algebraMap_val (r : F) :
+    algebraMap F (CrossProduct ha) r = r • 1 := rfl
+
+def ι : K →ₐ[F] CrossProduct ha where
+  toFun b := ⟨Pi.single 1 (b * (a (1, 1))⁻¹)⟩
+  map_one' := by
+    ext α
+    simp only [Prod.mk_one_one, Units.val_inv_eq_inv_val, _root_.one_mul, one_val]
+  map_mul' := by
+    intro b b'
+    ext α
+    simp only [Prod.mk_one_one, Units.val_inv_eq_inv_val, mul_val, crossProductMul_single_single,
+      AlgEquiv.one_apply]
+    rw [_root_.mul_one]
+    congr 1
+    simp only [_root_.mul_assoc]
+    congr 1
+    rw [mul_comm b']
+    congr 1
+    simp only [isUnit_iff_ne_zero, ne_eq, Units.ne_zero, not_false_eq_true, IsUnit.inv_mul_cancel,
+      _root_.mul_one]
+  map_zero' := by
+    ext α; simp
+  map_add' := by
+    intro b b'
+    ext α
+    simp only [Prod.mk_one_one, Units.val_inv_eq_inv_val, add_mul, Pi.single_apply, add_val,
+      Pi.add_apply]
+    split_ifs with h <;> aesop
+  commutes' := by
+    intro r
+    ext α
+    simp only [Prod.mk_one_one, Units.val_inv_eq_inv_val, algebraMap_val, smul_val, one_val,
+      crossProductSMul_single]
+    congr 1
+    rw [Algebra.smul_def]
+
 end CrossProduct
 
 end galois

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -10,7 +10,7 @@ suppress_compilation
 
 open FiniteDimensional BrauerGroup
 
-variable {F K : Type} [Field K] [Field F] [Algebra F K] [FiniteDimensional F K]
+variable {F K : Type} [Field K] [Field F] [Algebra F K]
 variable (X : BrGroup (K := F))
 
 variable (K) in
@@ -38,7 +38,6 @@ instance : Algebra F A := inferInstanceAs <| Algebra F A.carrier
 instance : IsSimpleOrder (TwoSidedIdeal A.ι.range) :=
   TwoSidedIdeal.orderIsoOfRingEquiv A.ιRange.symm |>.isSimpleOrder
 
-omit [FiniteDimensional F K] in
 lemma centralizerιRange : Subalgebra.centralizer F A.ι.range = A.ι.range := by
   let L : SubField F A :=
   { __ := A.ι.range
@@ -74,7 +73,6 @@ def aribitaryConjFactor : A.conjFactor σ :=
 
 variable {A ρ σ τ}
 
-omit [FiniteDimensional F K] in
 @[simp] lemma conjFactor_prop (x : A.conjFactor σ) (c : K) :
     x.1 * A.ι c * x.1⁻¹ = A.ι (σ c) := x.2 c |>.symm
 
@@ -84,7 +82,6 @@ def mul' (x : A.conjFactor σ) (y : A.conjFactor τ) : A.conjFactor (σ * τ) :=
   rw [← _root_.mul_assoc (A.ι c), ← mul_assoc (y.1 : A), ← mul_assoc (y.1 : A),
     conjFactor_prop, ← _root_.mul_assoc, conjFactor_prop]⟩
 
-omit [FiniteDimensional F K] in
 @[simp]
 lemma mul'_coe (x : A.conjFactor σ) (y : A.conjFactor τ) : (mul' x y).1.1 = x.1 * y.1 := rfl
 
@@ -287,7 +284,6 @@ section double
 
 variable {σ τ : K ≃ₐ[F] K}
 
-omit [FiniteDimensional F K] in
 lemma exists_iso :
     Nonempty (A ≃ₐ[F] B) := by
   obtain ⟨D, _, _, m, n, hm, hn, ⟨isoA⟩, ⟨isoB⟩⟩ :=
@@ -320,19 +316,16 @@ def iso : A.carrier ≃ₐ[F] B.carrier := exists_iso A B |>.some
 def isoConjCoeff : Bˣ :=
   SkolemNoether' F B K (AlgHom.comp (A.iso B).toAlgHom A.ι) B.ι |>.choose
 
-omit [FiniteDimensional F K] in
 lemma isoConjCoeff_spec :
     ∀ r : K, B.ι r = (A.isoConjCoeff B) * (A.iso B <| A.ι r) * (A.isoConjCoeff B)⁻¹ :=
   SkolemNoether' F B K (AlgHom.comp (A.iso B).toAlgHom A.ι) B.ι |>.choose_spec
 
-omit [FiniteDimensional F K] in
 lemma isoConjCoeff_spec' :
     ∀ r : K, (A.isoConjCoeff B)⁻¹ * B.ι r * (A.isoConjCoeff B) = (A.iso B <| A.ι r) := by
   intro c
   rw [A.isoConjCoeff_spec B c]
   simp [_root_.mul_assoc]
 
-omit [FiniteDimensional F K] in
 lemma isoConjCoeff_spec'' (c : K) (x : A.conjFactor σ):
     B.ι (σ c) =
     (A.isoConjCoeff B * (A.iso B <| x.1) * (A.isoConjCoeff B)⁻¹) *
@@ -361,7 +354,6 @@ def pushConjFactor (x : A.conjFactor σ) : B.conjFactor σ where
     simp only [Units.inv_mk]
     rw [isoConjCoeff_spec'']
 
-omit [FiniteDimensional F K] in
 @[simp] lemma pushConjFactor_coe (x : A.conjFactor σ) :
     (A.pushConjFactor B x).1.1 = A.isoConjCoeff B * (A.iso B <| x.1) * (A.isoConjCoeff B)⁻¹ :=
     rfl
@@ -485,9 +477,10 @@ variable (F K) in
 noncomputable def galAct : Rep ℤ (K ≃ₐ[F] K) :=
   Rep.ofMulDistribMulAction (K ≃ₐ[F] K) Kˣ
 
-omit [FiniteDimensional F K] in
 @[simp] lemma galAct_ρ_apply (σ : K ≃ₐ[F] K) (x : Kˣ) :
     (galAct F K).ρ σ (.ofMul x) = .ofMul (Units.map σ x) := rfl
+
+variable [FiniteDimensional F K]
 
 lemma mem_relativeBrGroup_iff_exists_goodRep (X : BrGroup (K := F)) :
     X ∈ RelativeBrGroup K F ↔
@@ -515,7 +508,6 @@ variable {X : BrGroup (K := F)} (A : GoodRep K X)
 def toH2 (x_ : Π σ, A.conjFactor σ) : groupCohomology.H2 (galAct F K) :=
 Quotient.mk'' <| twoCocyclesOfIsMulTwoCocycle (f := A.toTwoCocycles x_)
   (A.isTwoCocyles x_)
-
 
 end GoodRep
 

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -968,7 +968,7 @@ instance : SMul F (CrossProduct ha) where
 lemma smul_val (r : F) (x : CrossProduct ha) :
     (r • x).val = crossProductSMul r x.val := rfl
 
-instance : Algebra F (CrossProduct ha) where
+instance algebra : Algebra F (CrossProduct ha) where
   toFun r := r • 1
   map_one' := by
     ext α

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -247,24 +247,24 @@ lemma conjFactorCompCoeff_comp_comp
   simpa using conjFactorCompCoeff_comp_comp₃ xρ xσ xτ xρσ xστ xρστ
 
 variable (A) in
-def toTwoCocycles : ((K ≃ₐ[F] K) × (K ≃ₐ[F] K)) → Kˣ :=
+def toTwoCocycles (x_ : Π σ, A.conjFactor σ) : ((K ≃ₐ[F] K) × (K ≃ₐ[F] K)) → Kˣ :=
 fun p =>
   conjFactorCompCoeffAsUnit
-    (A.aribitaryConjFactor p.1)
-    (A.aribitaryConjFactor p.2)
-    (A.aribitaryConjFactor <| p.1 * p.2)
+    (x_ p.1)
+    (x_ p.2)
+    (x_ <| p.1 * p.2)
 
 variable (ρ σ τ) in
-lemma toTwoCocycles_cond :
-    ρ (A.toTwoCocycles (σ, τ)).1 * A.toTwoCocycles (ρ, σ * τ) =
-    A.toTwoCocycles (ρ, σ) * A.toTwoCocycles (ρ * σ, τ) := by
+lemma toTwoCocycles_cond (x_ : Π σ, A.conjFactor σ) :
+    ρ (A.toTwoCocycles x_ (σ, τ)).1 * A.toTwoCocycles x_ (ρ, σ * τ) =
+    A.toTwoCocycles x_ (ρ, σ) * A.toTwoCocycles x_ (ρ * σ, τ) := by
   delta toTwoCocycles
   dsimp only [conjFactorCompCoeffAsUnit, AlgEquiv.mul_apply]
   rw [conjFactorCompCoeff_comp_comp]
   rfl
 
-lemma isTwoCocyles :
-    groupCohomology.IsMulTwoCocycle A.toTwoCocycles := by
+lemma isTwoCocyles (x_ : Π σ, A.conjFactor σ) :
+    groupCohomology.IsMulTwoCocycle (A.toTwoCocycles x_) := by
   intro ρ σ τ
   ext : 1
   simp only [Units.val_mul]
@@ -432,35 +432,35 @@ lemma compare_conjFactorCompCoeff
 def trivialFactorSet (c : (K ≃ₐ[F] K) → Kˣ) : ((K ≃ₐ[F] K) × (K ≃ₐ[F] K)) → Kˣ :=
 fun p => c p.1 * Units.map p.1.toRingEquiv.toRingHom.toMonoidHom (c p.2) * (c (p.1 * p.2))⁻¹
 
-lemma compare_toTwoCocycles :
-    B.toTwoCocycles (σ, τ) *
-    A.pushConjFactorCoeffAsUnit B (A.aribitaryConjFactor (σ * τ)) (B.aribitaryConjFactor (σ * τ)) =
-    A.pushConjFactorCoeffAsUnit B (A.aribitaryConjFactor σ) (B.aribitaryConjFactor σ) *
-    Units.map σ (A.pushConjFactorCoeffAsUnit B (A.aribitaryConjFactor τ) (B.aribitaryConjFactor τ)) *
-    A.toTwoCocycles (σ, τ) := by
+lemma compare_toTwoCocycles (x_ : Π σ, A.conjFactor σ) (y_ : Π σ, B.conjFactor σ) :
+    B.toTwoCocycles y_ (σ, τ) *
+    A.pushConjFactorCoeffAsUnit B (x_ (σ * τ)) (y_ (σ * τ)) =
+    A.pushConjFactorCoeffAsUnit B (x_ σ) (y_ σ) *
+    Units.map σ (A.pushConjFactorCoeffAsUnit B (x_ τ) (y_ τ)) *
+    A.toTwoCocycles x_ (σ, τ) := by
   delta toTwoCocycles
   dsimp only
   have := A.compare_conjFactorCompCoeff B
-    (A.aribitaryConjFactor σ) (B.aribitaryConjFactor σ)
-    (A.aribitaryConjFactor τ) (B.aribitaryConjFactor τ)
-    (A.aribitaryConjFactor _) (B.aribitaryConjFactor _)
+    (x_ σ) (y_ σ)
+    (x_ τ) (y_ τ)
+    (x_ _) (y_ _)
   simp only [← _root_.mul_assoc] at this
   ext : 1
   dsimp
   rw [this]
 
-lemma compare_toTwoCocycles' :
-    groupCohomology.IsMulTwoCoboundary (B.toTwoCocycles / A.toTwoCocycles) := by
+lemma compare_toTwoCocycles' (x_ : Π σ, A.conjFactor σ) (y_ : Π σ, B.conjFactor σ) :
+    groupCohomology.IsMulTwoCoboundary (B.toTwoCocycles y_ / A.toTwoCocycles x_) := by
   fconstructor
   · refine fun σ =>
-      A.pushConjFactorCoeffAsUnit B (A.aribitaryConjFactor σ) (B.aribitaryConjFactor σ)
+      A.pushConjFactorCoeffAsUnit B (x_ σ) (y_ σ)
   intro σ τ
   dsimp
   symm
   rw [div_eq_iff_eq_mul, div_eq_mul_inv, mul_comm (Units.map _ _)]
   simp only [_root_.mul_assoc]
   symm
-  rw [inv_mul_eq_iff_eq_mul, mul_comm _ (B.toTwoCocycles _)]
+  rw [inv_mul_eq_iff_eq_mul, mul_comm _ (B.toTwoCocycles y_ _)]
   symm
   erw [compare_toTwoCocycles]
   simp only [← _root_.mul_assoc]
@@ -502,17 +502,19 @@ namespace GoodRep
 
 variable {X : BrGroup (K := F)} (A : GoodRep K X)
 
-def toH2 : groupCohomology.H2 (galAct F K) :=
-Quotient.mk'' <| twoCocyclesOfIsMulTwoCocycle (f := A.toTwoCocycles) A.isTwoCocyles
+def toH2 (x_ : Π σ, A.conjFactor σ) : groupCohomology.H2 (galAct F K) :=
+Quotient.mk'' <| twoCocyclesOfIsMulTwoCocycle (f := A.toTwoCocycles x_)
+  (A.isTwoCocyles x_)
 
 
 end GoodRep
 
 def RelativeBrGroup.toSnd :  RelativeBrGroup K F → groupCohomology.H2 (galAct F K) :=
-  fun X => (goodRep X).toH2
+  fun X => (goodRep X).toH2 (goodRep X).aribitaryConjFactor
 
-lemma RelativeBrGroup.toSnd_wd (X : RelativeBrGroup K F) (A : GoodRep K X.1) :
-    toSnd X = A.toH2 := by
+lemma RelativeBrGroup.toSnd_wd (X : RelativeBrGroup K F)
+    (A : GoodRep K X.1) (x_ : Π σ, A.conjFactor σ) :
+    toSnd X = A.toH2 x_ := by
   erw [Submodule.Quotient.eq]
   set lhs := _; change lhs ∈ _
   have : IsMulTwoCoboundary (G := K ≃ₐ[F] K) (M := Kˣ) (lhs.1) := by

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -1217,7 +1217,7 @@ lemma x__conj (c : K) : x_ ha σ * ι ha c * (x_ ha σ)⁻¹ = ι ha (σ c) := b
   change _ * ((x_ ha σ).1 * _) = _
   simp
 
-instance : Module K (CrossProduct ha) where
+instance module : Module K (CrossProduct ha) where
   smul c x := ι ha c * x
   one_smul := by intros; show _ * _ = _; simp
   mul_smul := by intros; show _ * _ = _ * (_ * _); simp [_root_.mul_assoc]

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -2,12 +2,249 @@ import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
 
 import BrauerGroup.Subfield.splitting
 
+import BrauerGroup.Subfield.Subfield
+
+suppress_compilation
 
 #check groupCohomology.H2
 
-variable (K F : Type) [Field K] [Field F] [Algebra F K]
+open FiniteDimensional
 
-noncomputable example : Rep ℤ (K ≃ₐ[F] K) :=
+variable (F K : Type) [Field K] [Field F] [Algebra F K] [FiniteDimensional F K]
+
+structure GoodRep where
+carrier : CSA.{0, 0} F
+ι : K →ₐ[F] carrier
+dim_eq : finrank F carrier = (finrank F K) ^ 2
+
+namespace GoodRep
+
+variable (A : GoodRep F K)
+
+instance : CoeSort (GoodRep F K) Type where
+  coe A := A.carrier
+
+variable {K F}
+
+def ιRange : K ≃ₐ[F] A.ι.range :=
+AlgEquiv.ofInjective _ (RingHom.injective _)
+
+instance : Algebra F A := inferInstanceAs <| Algebra F A.carrier
+
+instance : IsSimpleOrder (TwoSidedIdeal A.ι.range) :=
+  TwoSidedIdeal.orderIsoOfRingEquiv A.ιRange.symm |>.isSimpleOrder
+
+lemma centralizerιRange : Subalgebra.centralizer F A.ι.range = A.ι.range := by
+  let L : SubField F A :=
+  { __ := A.ι.range
+    mul_comm := sorry
+    inverse := sorry }
+  change Subalgebra.centralizer F (L.toSubalgebra : Set A) = L.toSubalgebra
+  apply cor_two_3to1
+  apply cor_two_2to3
+  change finrank F A = finrank F A.ι.range * finrank F A.ι.range
+  rw [A.dim_eq, pow_two, LinearEquiv.finrank_eq (f := A.ιRange.toLinearEquiv.symm)]
+
+variable (ρ σ τ : K ≃ₐ[F] K)
+
+def conjFactor : (σ : K ≃ₐ[F] K) → Type :=
+  fun σ => { a : Aˣ //  ∀ x : K, A.ι (σ x) = a * A.ι x * a⁻¹ }
+
+def aribitaryConjFactor : A.conjFactor σ :=
+⟨SkolemNoether' F A K A.ι (A.ι.comp σ) |>.choose, fun x =>
+  SkolemNoether' F A K A.ι (A.ι.comp σ) |>.choose_spec x⟩
+
+variable {A ρ σ τ}
+
+omit [FiniteDimensional F K] in
+@[simp] lemma conjFactor_prop (x : A.conjFactor σ) (c : K) :
+    x.1 * A.ι c * x.1⁻¹ = A.ι (σ c) := x.2 c |>.symm
+
+def mul' (x : A.conjFactor σ) (y : A.conjFactor τ) : A.conjFactor (σ * τ) :=
+⟨x.1 * y.1, fun c => by
+  simp only [AlgEquiv.mul_apply, Units.val_mul, mul_assoc, mul_inv_rev]
+  rw [← mul_assoc (A.ι c), ← mul_assoc (y.1 : A), ← mul_assoc (y.1 : A),
+    conjFactor_prop, ← mul_assoc, conjFactor_prop]⟩
+
+lemma conjFactor_rel_aux (x y : A.conjFactor σ) :
+    ∃ (c : K), x.1 = y.1 * A.ι c := by
+  have mem1 : (y.1⁻¹ * x.1 : A) ∈ Subalgebra.centralizer F A.ι.range := by
+    rw [Subalgebra.mem_centralizer_iff]
+    rintro _ ⟨z, rfl⟩
+    have := x.2 z |>.symm.trans (y.2 z)
+    apply_fun (x.1⁻¹.1 * ·) at this
+    simp only [← mul_assoc, Units.inv_mul, one_mul] at this
+    apply_fun (· * x.1.1) at this
+    simp only [Units.inv_mul_cancel_right] at this
+    simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe]
+    conv_rhs => rw [this]
+    simp only [mul_assoc, Units.mul_inv_cancel_left, Units.inv_mul_cancel_left]
+
+  rw [A.centralizerιRange, AlgHom.mem_range] at mem1
+  obtain ⟨c, hc⟩ := mem1
+  use c
+  simp only [hc, Units.mul_inv_cancel_left]
+
+lemma conjFactor_rel (x y : A.conjFactor σ) :
+    ∃! (c : K), x.1 = y.1 * A.ι c := by
+  obtain ⟨c, hc⟩ := conjFactor_rel_aux x y
+  refine ⟨c, hc, fun c' (hc' : _ = _) => ?_⟩
+  rw [hc] at hc'
+  simp only [Units.mul_right_inj] at hc'
+  exact RingHom.injective _ hc' |>.symm
+
+def conjFactorTwistCoeff (x y : A.conjFactor σ) : K := conjFactor_rel x y |>.choose
+
+lemma conjFactorTwistCoeff_spec (x y : A.conjFactor σ) : x.1 = y.1 * A.ι (conjFactorTwistCoeff x y) :=
+  conjFactor_rel x y |>.choose_spec.1
+
+lemma conjFactorTwistCoeff_unique (x y : A.conjFactor σ) (c : K) (h : x.1 = y.1 * A.ι c) :
+    c = conjFactorTwistCoeff x y :=
+  conjFactor_rel x y |>.choose_spec.2 _ h
+
+@[simp]
+lemma conjFactorTwistCoeff_self (x : A.conjFactor σ) : conjFactorTwistCoeff x x = 1 :=
+  Eq.symm <| conjFactorTwistCoeff_unique _ _ _ <| by simp
+
+@[simps]
+def conjFactorTwistCoeffAsUnit (x y : A.conjFactor σ) : Kˣ where
+  val := conjFactorTwistCoeff x y
+  inv := conjFactorTwistCoeff y x
+  val_inv := by
+    simpa using conjFactorTwistCoeff_unique y y
+      (conjFactorTwistCoeff x y * conjFactorTwistCoeff y x)
+      (by simp only [map_mul, ← mul_assoc, ← conjFactorTwistCoeff_spec])
+  inv_val := by
+    simpa using conjFactorTwistCoeff_unique x x
+      (conjFactorTwistCoeff y x * conjFactorTwistCoeff x y)
+      (by simp only [map_mul, ← mul_assoc, ← conjFactorTwistCoeff_spec])
+
+@[simp]
+lemma conjFactorTwistCoeff_swap (x y : A.conjFactor σ) :
+    conjFactorTwistCoeff x y * conjFactorTwistCoeff y x = 1 :=
+    conjFactorTwistCoeffAsUnit x y |>.val_inv
+
+@[simp]
+lemma conjFactorTwistCoeff_swap' (x y : A.conjFactor σ) :
+    conjFactorTwistCoeff y x * conjFactorTwistCoeff x y = 1 :=
+    conjFactorTwistCoeffAsUnit y x |>.val_inv
+
+@[simp]
+lemma conjFactorTwistCoeff_swap'' (x y : A.conjFactor σ) :
+    A.ι (conjFactorTwistCoeff x y) * A.ι (conjFactorTwistCoeff y x) = 1 := by
+  simp [← map_mul]
+
+@[simp]
+lemma conjFactorTwistCoeff_swap''' (x y : A.conjFactor σ) :
+    A.ι (conjFactorTwistCoeff y x) * A.ι (conjFactorTwistCoeff x y) = 1 := by
+  simp [← map_mul]
+
+lemma conjFactorTwistCoeff_spec' (x y : A.conjFactor σ) :
+    x.1 = A.ι (σ <| conjFactorTwistCoeff x y) * y.1 := by
+  calc x.1.1
+    _ = (x.1 * A.ι (conjFactorTwistCoeff x y) * x.1⁻¹) * (x.1 * A.ι (conjFactorTwistCoeff y x)) := by
+        simp only [mul_assoc, Units.inv_mul_cancel_left, conjFactorTwistCoeff_swap'', mul_one]
+    _ = A.ι (σ <| conjFactorTwistCoeff x y) * (x.1 * A.ι (conjFactorTwistCoeff y x)) := by
+        simp only [conjFactor_prop]
+    _ = A.ι (σ <| conjFactorTwistCoeff x y) * y.1 := by
+        simp [← conjFactorTwistCoeff_spec]
+
+def conjFactorCompCoeff (x : A.conjFactor σ) (y : A.conjFactor τ) (z : A.conjFactor (σ * τ)) : K :=
+    σ <| τ <| conjFactorTwistCoeff (mul' x y) z
+
+@[simp]
+def conjFactorCompCoeffAsUnit
+    (x : A.conjFactor σ) (y : A.conjFactor τ) (z : A.conjFactor (σ * τ)) : Kˣ where
+  val := conjFactorCompCoeff x y z
+  inv := σ <| τ <| conjFactorTwistCoeff z (mul' x y)
+  val_inv := by
+    simp only [conjFactorCompCoeff, ← map_mul, conjFactorTwistCoeff_swap, map_one]
+  inv_val := by
+    simp only [conjFactorCompCoeff, ← map_mul, conjFactorTwistCoeff_swap, map_one]
+
+lemma conjFactorCompCoeff_spec (x : A.conjFactor σ) (y : A.conjFactor τ) (z : A.conjFactor (σ * τ)) :
+    (x.1 * y.1 : A) = A.ι (conjFactorCompCoeff x y z) * z.1 :=
+  conjFactorTwistCoeff_spec' (mul' x y) z
+
+lemma conjFactorCompCoeff_spec' (x : A.conjFactor σ) (y : A.conjFactor τ) (z : A.conjFactor (σ * τ)) :
+    A.ι (σ <| τ <| conjFactorTwistCoeff z (mul' x y)) * (x.1 * y.1 : A) = z.1 := by
+  rw [conjFactorCompCoeff_spec (z := z), ← mul_assoc, ← map_mul]
+  have := conjFactorCompCoeffAsUnit x y z |>.inv_val
+  erw [this]
+  simp
+
+lemma conjFactorCompCoeff_comp_comp₁
+    (xρ : A.conjFactor ρ) (xσ : A.conjFactor σ) (xτ : A.conjFactor τ)
+    (xρσ : A.conjFactor (ρ * σ))
+    (xρστ : A.conjFactor (ρ * σ * τ)) :
+    xρ.1.1 * xσ.1 * xτ.1 =
+    A.ι (conjFactorCompCoeff xρ xσ xρσ) *
+    A.ι (conjFactorCompCoeff xρσ xτ xρστ) *
+    xρστ.1 := by
+  rw [conjFactorCompCoeff_spec (z := xρσ), mul_assoc,
+    conjFactorCompCoeff_spec (z := xρστ), ← mul_assoc]
+
+lemma conjFactorCompCoeff_comp_comp₂
+    (xρ : A.conjFactor ρ) (xσ : A.conjFactor σ) (xτ : A.conjFactor τ)
+    (xστ : A.conjFactor (σ * τ))
+    (xρστ : A.conjFactor (ρ * σ * τ)) :
+    xρ.1.1 * (xσ.1 * xτ.1) =
+    A.ι (ρ <| conjFactorCompCoeff xσ xτ xστ) *
+    A.ι (conjFactorCompCoeff xρ xστ xρστ) *
+    xρστ.1 := by
+  have eq1 :
+      xρ.1 * A.ι (conjFactorCompCoeff xσ xτ xστ) =
+      A.ι (ρ <| conjFactorCompCoeff xσ xτ xστ) * xρ.1 := by
+    have := xρ.2 (conjFactorCompCoeff xσ xτ xστ)
+    conv_rhs => rw [this, mul_assoc]
+    simp
+  conv_lhs => rw [conjFactorCompCoeff_spec (z := xστ), ← mul_assoc, eq1]
+  conv_rhs => rw [mul_assoc, ← conjFactorCompCoeff_spec, ← mul_assoc]
+
+lemma conjFactorCompCoeff_comp_comp₃
+    (xρ : A.conjFactor ρ) (xσ : A.conjFactor σ) (xτ : A.conjFactor τ)
+    (xρσ : A.conjFactor (ρ * σ)) (xστ : A.conjFactor (σ * τ))
+    (xρστ : A.conjFactor (ρ * σ * τ)) :
+    A.ι (conjFactorCompCoeff xρ xσ xρσ) *
+    A.ι (conjFactorCompCoeff xρσ xτ xρστ) *
+    xρστ.1 =
+    A.ι (ρ <| conjFactorCompCoeff xσ xτ xστ) *
+    A.ι (conjFactorCompCoeff xρ xστ xρστ) *
+    xρστ.1 := by
+  rw [← conjFactorCompCoeff_comp_comp₁, ← conjFactorCompCoeff_comp_comp₂, mul_assoc]
+
+lemma conjFactorCompCoeff_comp_comp
+    (xρ : A.conjFactor ρ) (xσ : A.conjFactor σ) (xτ : A.conjFactor τ)
+    (xρσ : A.conjFactor (ρ * σ)) (xστ : A.conjFactor (σ * τ))
+    (xρστ : A.conjFactor (ρ * σ * τ)) :
+    conjFactorCompCoeff xρ xσ xρσ *
+    conjFactorCompCoeff xρσ xτ xρστ =
+    (ρ <| conjFactorCompCoeff xσ xτ xστ) *
+    conjFactorCompCoeff xρ xστ xρστ := by
+  apply_fun A.ι using RingHom.injective _
+  simpa using conjFactorCompCoeff_comp_comp₃ xρ xσ xτ xρσ xστ xρστ
+
+variable (A) in
+def toSnd : ((K ≃ₐ[F] K) × (K ≃ₐ[F] K)) → Kˣ :=
+fun p =>
+  conjFactorCompCoeffAsUnit
+    (A.aribitaryConjFactor p.1)
+    (A.aribitaryConjFactor p.2)
+    (A.aribitaryConjFactor <| p.1 * p.2)
+
+def toSnd_cond :
+    ρ (A.toSnd (σ, τ)).1 * A.toSnd (ρ, σ * τ) =
+    A.toSnd (ρ, σ) * A.toSnd (ρ * σ, τ) := by
+  delta toSnd
+  dsimp only [conjFactorCompCoeffAsUnit, AlgEquiv.mul_apply]
+  rw [conjFactorCompCoeff_comp_comp]
+  rfl
+
+end GoodRep
+
+
+
+noncomputable def galAct : Rep ℤ (K ≃ₐ[F] K) :=
   Rep.of (V := Additive Kˣ)
     { toFun := fun σ =>
       { toFun := fun x => ⟨σ x.1, σ x.2, by simp, by simp⟩

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -38,11 +38,21 @@ instance : Algebra F A := inferInstanceAs <| Algebra F A.carrier
 instance : IsSimpleOrder (TwoSidedIdeal A.ι.range) :=
   TwoSidedIdeal.orderIsoOfRingEquiv A.ιRange.symm |>.isSimpleOrder
 
+omit [FiniteDimensional F K] in
 lemma centralizerιRange : Subalgebra.centralizer F A.ι.range = A.ι.range := by
   let L : SubField F A :=
   { __ := A.ι.range
-    mul_comm := sorry
-    inverse := sorry }
+    mul_comm := by
+      rintro _ _ ⟨x, rfl⟩ ⟨y, rfl⟩
+      simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, ← map_mul, mul_comm]
+    inverse := by
+      rintro _ ⟨x, rfl⟩ hx
+      refine ⟨A.ι x⁻¹, ?_, ?_⟩
+      · simp
+      · simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, ← map_mul]
+        rw [mul_inv_cancel₀, map_one]
+        rintro rfl
+        simp at hx }
   change Subalgebra.centralizer F (L.toSubalgebra : Set A) = L.toSubalgebra
   apply cor_two_3to1
   apply cor_two_2to3

--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -1,0 +1,30 @@
+import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
+
+import BrauerGroup.Subfield.splitting
+
+
+#check groupCohomology.H2
+
+variable (K F : Type) [Field K] [Field F] [Algebra F K]
+
+noncomputable example : Rep ℤ (K ≃ₐ[F] K) :=
+  Rep.of (V := Additive Kˣ)
+    { toFun := fun σ =>
+      { toFun := fun x => ⟨σ x.1, σ x.2, by simp, by simp⟩
+        map_add' := fun (x : Kˣ) (y : Kˣ) => by
+          refine Units.ext ?_
+          change σ (x.1 * y.1) = σ _ * σ _
+          simp only [map_mul]
+        map_smul' := by
+          rintro m x
+          dsimp
+          apply_fun Additive.toMul
+          rw [toMul_zsmul]
+          simp only [Units.val_inv_eq_inv_val, map_inv₀]
+          refine Units.ext ?_
+          dsimp
+          change σ (_ ^ m : Kˣ).1 = _ -- r • σ x.1
+          simp only [Units.val_zpow_eq_zpow_val, map_zpow₀]
+          rfl }
+      map_one' := rfl
+      map_mul' := by intros; rfl }


### PR DESCRIPTION
A good representative of $X \in Br(K)$ is a $(\dim_F K)^2$-dimensional $F$-CSA $A \in X$ with an embedding $K \to A$.

## What's finished

In this PR, I define this structure `GoodRep` and prove some stuff:
- $X$ is in the relative Brauer group $Br(K/F)$ if and only if some good representative exists. `mem_relativeBrGroup_iff_exists_goodRep`
- if $A, B$ are two good representative then $A \cong B$ as $F$-algebra `GoodRep.iso`
- starting from a good rep $A$, we can construct a $2$-cocycle `GoodRep.toTwoCocycles`
- the $2$-cocycle obtained by $A$ and $B$ where $A, B$ are good reps, are $2$-cohomologous `groupCohomology.IsMulTwoCoboundary`
- so a function from $Br(K/F)$ to $H^2$ is well defined and can be compute by any good rep and any conjugation factors, `RelativeBrGroup.toSnd` and `RelativeBrGroup.toSnd_wd`

Conversely, if $a$ is a $2$-coboundary
- we define $A = \bigoplus_{\sigma} K$ with a different product `GoodRep.crossProductMul`, we can turn it into a $F$-algebra (`GoodRep.CrossProduct.algebra`) and a $K$-module (`GoodRep.CrossProduct.module`)
- the $F$-dimension of $A$ is equal to $(\dim _F K)^2$ (`GoodRep.CrossProduct.dim_eq_square`)
- the embedding $K \to A$ is defined as $b \mapsto b * a(id, id)^{-1}$ (`GoodRep.CrossProduct.ι`)
- we have conjugation factor with expected properties (`GoodRep.CrossProduct.x_`, `GoodRep.CrossProduct.x__conj`, `GoodRep.CrossProduct.x__mul`): $x_{\sigma}x_{\tau}=a(\sigma, \tau)'x_{\sigma\tau}$ and $x_{\sigma}b'x_{\sigma}^{-1}=\sigma(b)'$

~~So basically proposition 3.10, lemma 3.11, proposition 3.12 (a) (b) (c) is done.~~

So basically proposition 3.10, lemma 3.11, proposition 3.12 are done

## What's missing

- [x] : cross product is central (proposition 3.12) [27-Oct, `GoodRep.CrossProduct.is_central`]
- [x] : cross product is simple (proposition 3.12) [28-Oct, `GoodRep.CrossProduct.is_simple`]
- [ ] : cross product is the same if two $2$-cocycles are cohomologous (same means they represent the same brauer equivalence class) (corollary 3.13)
- [ ] : two direction compose to identity (corollary 3.13)
- [ ] : $a \mapsto A$ the crossproduct is a group homomorphism (theorem 3.14) <- this looks like a long proof
