### PR TITLE
Fix whnf timeouts in ToSecond.lean at mathlib c453659

### DIFF
--- a/BrauerGroup/ToSecond.lean
+++ b/BrauerGroup/ToSecond.lean
@@ -5,6 +5,8 @@ import Mathlib.RepresentationTheory.Homological.GroupCohomology.LowDegree
 
 suppress_compilation
 
+seal Finsupp.onFinset_support
+
 open FiniteDimensional BrauerGroup Module groupCohomology
 
 variable {F K : Type} [Field K] [Field F] [Algebra F K]


### PR DESCRIPTION
# From Human

I just asked Claude to fix the timeouts in #24. Feel free to close this, and if it's not helpful, let me know. I am essentially acting as a very thin wrapper between you and Claude here.

# From Claude

Fixes the deterministic timeouts in #24 (`ToSecond.lean:705` and `:801`).

## Root cause

mathlib c453659 ([#32861](https://github.com/leanprover-community/mathlib4/pull/32861)) replaced `private irreducible_def` with module-system `@[no_expose] def` in five files. One of them is `Finsupp.onFinset_support` — the support of `Finsupp.onFinset`, which underlies `Finsupp.zipWith` and hence every `Finsupp` addition/subtraction/`mapRange`.

`@[no_expose]` only hides the definition body from other *modules*. BrauerGroup doesn't use the module system, so for this project the definition went from **irreducible** to **freely unfoldable**. `whnf` calls that previously failed fast at the irreducible constant (and fell back to other unification strategies) now unfold into the underlying `Classical.decEq`/`Finset.filter` term and diverge:

- `ToSecond.lean:705` — elaborating `Quotient.lift fromCocycles₂ <| by …` in `fromSnd`;
- `ToSecond.lean:801` — the `erw [val_smul, …]` chain over `CrossProductAlgebra` (a structure wrapping `Finsupp`) terms.

The remaining errors in the failure log (`Unknown identifier fromSnd`, etc.) are all cascading from the first timeout.

## Fix

One line: `seal Finsupp.onFinset_support` at the top of `ToSecond.lean`, restoring the pre-c453659 irreducibility for this file. Both timeouts disappear and the file elaborates in its usual ~14s. `lake build BrauerGroup` then succeeds for the whole library at c453659 (verified locally, toolchain v4.27.0-rc1).

(For context: #22 doesn't hit this because the v4.31 port rewrote the `fromSnd`/`toSnd_fromSnd` proof bodies for the new cohomology API, avoiding these particular `whnf` paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)